### PR TITLE
Fix navbar and footer overlapping content on mobile

### DIFF
--- a/src/Components/Header/index.js
+++ b/src/Components/Header/index.js
@@ -1,10 +1,14 @@
 import './index.css';
 import ResponsiveAppBar from '../Navbar';
+import Toolbar from '@mui/material/Toolbar';
 
 function Header(){
-
     return (
-        <ResponsiveAppBar/>
+        <>
+            <ResponsiveAppBar/>
+            {/* Offset for fixed app bar */}
+            <Toolbar />
+        </>
     )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,8 @@ body{
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  /* Space for fixed footer */
+  padding-bottom: 60px;
 }
 
 .containerpage{


### PR DESCRIPTION
## Summary
- ensure page content starts below fixed AppBar
- add bottom padding so fixed footer no longer covers content

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689defe9f01c832c836997cf40ba2d32